### PR TITLE
Fix build issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ kotlin.code.style=official
 xcodeproj=./iosApp
 android.useAndroidX=true
 org.gradle.warning.mode=all
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 kotlin.mpp.androidSourceSetLayoutVersion=2
 
 android.compileSdk=33

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -104,7 +104,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_18
         targetCompatibility = JavaVersion.VERSION_18
-        isCoreLibraryDesugaringEnabled = true
     }
 }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -101,6 +101,11 @@ android {
             isMinifyEnabled = true
         }
     }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_18
+        targetCompatibility = JavaVersion.VERSION_18
+        isCoreLibraryDesugaringEnabled = true
+    }
 }
 
 sqldelight {


### PR DESCRIPTION
This PR fixes issues described in #23

```log
> Task :androidApp:mergeExtDexDebug FAILED
    AGPBI: {"kind":"error","text":"java.lang.OutOfMemoryError: Java heap space","sources":[{}],"tool":"D8"}
        com.android.builder.dexing.DexArchiveMergerException: Error while merging dex archives: 
        ...
```

```log
Execution failed for task ':shared:compileDebugKotlinAndroid'.
> 'compileDebugJavaWithJavac' task (current target is 1.8) and 'compileDebugKotlinAndroid' task (current target is 18) jvm target compatibility should be set to the same Java version.
  Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain
  ...
```

