### PR TITLE
Build Fixes, Fix Tests

### DIFF
--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -1,0 +1,1 @@
+-dontwarn org.slf4j.impl.StaticLoggerBinder

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -50,14 +50,13 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
                 implementation("io.ktor:ktor-client-okhttp:"+extra["ktor.version"])
                 implementation("app.cash.sqldelight:android-driver:"+extra["sqlDelight.version"])
             }
         }
         val androidUnitTest by getting {
             dependencies {
-                implementation(kotlin("test-junit"))
-                implementation("junit:junit:4.13.2")
                 implementation("app.cash.sqldelight:sqlite-driver:"+extra["sqlDelight.version"])
             }
         }

--- a/shared/src/androidUnitTest/kotlin/eu/baroncelli/dkmpsample/shared/TestUtils.kt
+++ b/shared/src/androidUnitTest/kotlin/eu/baroncelli/dkmpsample/shared/TestUtils.kt
@@ -1,22 +1,12 @@
 package eu.baroncelli.dkmpsample.shared
 
-import com.russhwolf.settings.MapSettings
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.russhwolf.settings.MapSettings
 import eu.baroncelli.dkmpsample.shared.datalayer.Repository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.runBlocking
 import mylocal.db.LocalDb
-import java.util.concurrent.Executors
-import kotlin.coroutines.CoroutineContext
 
-actual val testCoroutineContext: CoroutineContext =
-    Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-actual fun runBlockingTest(block: suspend CoroutineScope.() -> Unit) =
-    runBlocking(testCoroutineContext) { this.block() }
-
-actual fun getTestRepository() : Repository {
+actual fun getTestRepository(): Repository {
     val sqlDriver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
     LocalDb.Schema.create(sqlDriver)
-    return Repository(sqlDriver, MapSettings(), false)
+    return Repository(sqlDriver, MapSettings())
 }

--- a/shared/src/commonMain/kotlin/eu/baroncelli/dkmpsample/shared/datalayer/Repository.kt
+++ b/shared/src/commonMain/kotlin/eu/baroncelli/dkmpsample/shared/datalayer/Repository.kt
@@ -10,7 +10,7 @@ import eu.baroncelli.dkmpsample.shared.datalayer.sources.webservices.ApiClient
 import kotlinx.coroutines.*
 import mylocal.db.LocalDb
 
-class Repository(val sqlDriver: SqlDriver, val settings: Settings = Settings(), val useDefaultDispatcher: Boolean = true) {
+class Repository(val sqlDriver: SqlDriver, val settings: Settings = Settings()) {
 
     internal val webservices by lazy { ApiClient() }
     internal val localDb by lazy { LocalDb(sqlDriver, Countries.Adapter(IntColumnAdapter,IntColumnAdapter,IntColumnAdapter)) }
@@ -19,12 +19,8 @@ class Repository(val sqlDriver: SqlDriver, val settings: Settings = Settings(), 
 
     // we run each repository function on a Dispatchers.Default coroutine
     // we pass useDefaultDispatcher=false just for the TestRepository instance
-    suspend fun <T> withRepoContext (block: suspend () -> T) : T {
-        return if (useDefaultDispatcher) {
-            withContext(Dispatchers.Default) {
-                block()
-            }
-        } else {
+    suspend fun <T> withRepoContext(block: suspend () -> T): T {
+        return withContext(Dispatchers.Default) {
             block()
         }
     }

--- a/shared/src/commonMain/kotlin/eu/baroncelli/dkmpsample/shared/viewmodel/Navigation.kt
+++ b/shared/src/commonMain/kotlin/eu/baroncelli/dkmpsample/shared/viewmodel/Navigation.kt
@@ -2,6 +2,7 @@ package eu.baroncelli.dkmpsample.shared.viewmodel
 
 import eu.baroncelli.dkmpsample.shared.viewmodel.screens.CallOnInitValues
 import eu.baroncelli.dkmpsample.shared.viewmodel.screens.navigationSettings
+import kotlinx.coroutines.Job
 
 data class NavigationState (
     val currentLevel1ScreenIdentifier : ScreenIdentifier,
@@ -143,11 +144,11 @@ class Navigation(val stateManager : StateManager) {
 
     // ADD SCREEN TO BACKSTACK
 
-    fun addScreenToBackstack(screenIdentifier: ScreenIdentifier) {
+    fun addScreenToBackstack(screenIdentifier: ScreenIdentifier): Job? {
         debugLogger.log("addScreenToBackstack: "+screenIdentifier.URI)
         stateManager.currentVerticalBackstack.add(screenIdentifier)
         stateManager.currentVerticalNavigationLevelsMap[screenIdentifier.screen.navigationLevel] = screenIdentifier
-        stateManager.initScreen(screenIdentifier)
+        return stateManager.initScreen(screenIdentifier)
     }
 
 

--- a/shared/src/commonTest/kotlin/eu/baroncelli/dkmpsample/shared/TestUtils.kt
+++ b/shared/src/commonTest/kotlin/eu/baroncelli/dkmpsample/shared/TestUtils.kt
@@ -1,10 +1,5 @@
 package eu.baroncelli.dkmpsample.shared
 
 import eu.baroncelli.dkmpsample.shared.datalayer.Repository
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
-expect fun runBlockingTest(block: suspend CoroutineScope.()-> Unit)
-expect val testCoroutineContext: CoroutineContext
-
-expect fun getTestRepository() : Repository
+expect fun getTestRepository(): Repository

--- a/shared/src/commonTest/kotlin/eu/baroncelli/dkmpsample/shared/viewmodel/Tests.kt
+++ b/shared/src/commonTest/kotlin/eu/baroncelli/dkmpsample/shared/viewmodel/Tests.kt
@@ -1,44 +1,72 @@
 package eu.baroncelli.dkmpsample.shared.viewmodel
 
 import eu.baroncelli.dkmpsample.shared.datalayer.objects.CountryExtraData
+import eu.baroncelli.dkmpsample.shared.datalayer.objects.CountryListData
+import eu.baroncelli.dkmpsample.shared.datalayer.sources.localdb.countries.setCountriesList
 import eu.baroncelli.dkmpsample.shared.getTestRepository
-import eu.baroncelli.dkmpsample.shared.viewmodel.screens.Screen.*
-import eu.baroncelli.dkmpsample.shared.viewmodel.screens.countrydetail.CountryDetailState
-import eu.baroncelli.dkmpsample.shared.viewmodel.screens.countrieslist.*
+import eu.baroncelli.dkmpsample.shared.viewmodel.screens.Screen.CountriesList
+import eu.baroncelli.dkmpsample.shared.viewmodel.screens.Screen.CountryDetail
+import eu.baroncelli.dkmpsample.shared.viewmodel.screens.countrieslist.CountriesListParams
+import eu.baroncelli.dkmpsample.shared.viewmodel.screens.countrieslist.CountriesListState
+import eu.baroncelli.dkmpsample.shared.viewmodel.screens.countrieslist.CountriesListType
 import eu.baroncelli.dkmpsample.shared.viewmodel.screens.countrydetail.CountryDetailParams
+import eu.baroncelli.dkmpsample.shared.viewmodel.screens.countrydetail.CountryDetailState
 import eu.baroncelli.dkmpsample.shared.viewmodel.screens.countrydetail.CountryInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ViewModelTests {
 
-    val vm = DKMPViewModel(getTestRepository())
-    val navigation = vm.navigation
-    val stateProvider = navigation.stateProvider
-    val stateManager = navigation.stateManager
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+    val vm: DKMPViewModel = DKMPViewModel(getTestRepository())
+    val navigation: Navigation
+        get() = vm.navigation
+    val stateProvider: StateProvider
+        get() = navigation.stateProvider
+    val stateManager: StateManager
+        get() = navigation.stateManager
 
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     @Test
-    fun testCountriesListStateUpdate() {
-        val screenIdentifier = ScreenIdentifier.get(CountriesList,CountriesListParams(CountriesListType.ALL))
-        val screenInitSettings = screenIdentifier.getScreenInitSettings(navigation)
-        stateManager.addScreen(screenIdentifier, screenInitSettings)
+    fun testCountriesListStateUpdate() = runTest {
+        val screenIdentifier = ScreenIdentifier.get(CountriesList, CountriesListParams(CountriesListType.ALL))
+        navigation.addScreenToBackstack(screenIdentifier)?.join()
         stateManager.updateScreen(CountriesListState::class) {
             it.copy(favoriteCountries = mapOf("Italy" to true))
         }
-        val screenState = stateProvider.get(screenIdentifier) as CountriesListState
+        val screenState = stateProvider.getScreenStateFlow(screenIdentifier).value as CountriesListState
         assertTrue(screenState.favoriteCountries.containsKey("Italy"))
     }
 
     @Test
-    fun testCountryDetailStateUpdate() {
+    fun testCountryDetailStateUpdate() = runTest {
+        stateManager.dataRepository.localDb.setCountriesList(
+            listOf(
+                CountryListData(name = "Germany")
+            )
+        )
         val screenIdentifier = ScreenIdentifier.get(CountryDetail, CountryDetailParams("Germany"))
-        val screenInitSettings = screenIdentifier.getScreenInitSettings(navigation)
-        stateManager.addScreen(screenIdentifier, screenInitSettings)
+        navigation.addScreenToBackstack(screenIdentifier)?.join()
         stateManager.updateScreen(CountryDetailState::class) {
             it.copy(countryInfo = CountryInfo(_extraData = CountryExtraData(vaccines = "Pfizer, Moderna, AstraZeneca")))
         }
-        val screenState = stateProvider.get(screenIdentifier) as CountryDetailState
+        val screenState = stateProvider.getScreenStateFlow(screenIdentifier).value as CountryDetailState
         assertTrue(screenState.countryInfo.vaccinesList!!.contains("Pfizer"))
     }
 

--- a/shared/src/desktopTest/kotlin/eu/baroncelli/dkmpsample/shared/TestUtils.kt
+++ b/shared/src/desktopTest/kotlin/eu/baroncelli/dkmpsample/shared/TestUtils.kt
@@ -1,22 +1,12 @@
 package eu.baroncelli.dkmpsample.shared
 
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.russhwolf.settings.MapSettings
 import eu.baroncelli.dkmpsample.shared.datalayer.Repository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.newSingleThreadContext
-import kotlinx.coroutines.runBlocking
-import kotlin.coroutines.CoroutineContext
-import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import mylocal.db.LocalDb
 
-actual val testCoroutineContext: CoroutineContext =
-    newSingleThreadContext("testRunner")
-
-actual fun runBlockingTest(block: suspend CoroutineScope.() -> Unit) =
-    runBlocking(testCoroutineContext) { this.block() }
-
-actual fun getTestRepository() : Repository {
+actual fun getTestRepository(): Repository {
     val sqlDriver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
     LocalDb.Schema.create(sqlDriver)
-    return Repository(sqlDriver, MapSettings(), false)
+    return Repository(sqlDriver, MapSettings())
 }

--- a/shared/src/iosTest/kotlin/eu/baroncelli/dkmpsample/shared/TestUtils.kt
+++ b/shared/src/iosTest/kotlin/eu/baroncelli/dkmpsample/shared/TestUtils.kt
@@ -1,21 +1,11 @@
 package eu.baroncelli.dkmpsample.shared
 
+import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import com.russhwolf.settings.MapSettings
 import eu.baroncelli.dkmpsample.shared.datalayer.Repository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.newSingleThreadContext
-import kotlinx.coroutines.runBlocking
-import kotlin.coroutines.CoroutineContext
-import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import mylocal.db.LocalDb
 
-actual val testCoroutineContext: CoroutineContext =
-    newSingleThreadContext("testRunner")
-
-actual fun runBlockingTest(block: suspend CoroutineScope.() -> Unit) =
-    runBlocking(testCoroutineContext) { this.block() }
-
-actual fun getTestRepository() : Repository {
+actual fun getTestRepository(): Repository {
     val sqlDriver = NativeSqliteDriver(LocalDb.Schema, "test.db")
-    return Repository(sqlDriver, MapSettings(), false)
+    return Repository(sqlDriver, MapSettings())
 }


### PR DESCRIPTION
* Add android proguard with a rule that was needed to build
* Remove `runBlockingTest` use `kotlinx.coroutines.test.runTest`
* Return Job from addScreenToBackstack to allow tests to wait for addScreenToBackstack to complete, instead of having a test only `useDefaultDispatcher` boolean in `Repository` to force `withRepoContext` to run synchronously
